### PR TITLE
Add missing migration for uint256 optimization

### DIFF
--- a/src/Ztm.Data.Entity.Postgres/Migrations/20190806134352_RemoveUInt256Converter.Designer.cs
+++ b/src/Ztm.Data.Entity.Postgres/Migrations/20190806134352_RemoveUInt256Converter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NBitcoin;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,10 @@ using Ztm.Data.Entity.Postgres;
 namespace Ztm.Data.Entity.Postgres.Migrations
 {
     [DbContext(typeof(MainDatabase))]
-    partial class MainDatabaseModelSnapshot : ModelSnapshot
+    [Migration("20190806134352_RemoveUInt256Converter")]
+    partial class RemoveUInt256Converter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ztm.Data.Entity.Postgres/Migrations/20190806134352_RemoveUInt256Converter.cs
+++ b/src/Ztm.Data.Entity.Postgres/Migrations/20190806134352_RemoveUInt256Converter.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Ztm.Data.Entity.Postgres.Migrations
+{
+    public partial class RemoveUInt256Converter : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
There is a missing migration for #17. So this PR added it.