### PR TITLE
Make PostgreSQL for development not persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Zcoin Tokens Manager
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/zcoinofficial/ztm.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zcoinofficial/ztm/alerts/) [![Language grade: C#](https://img.shields.io/lgtm/grade/csharp/g/zcoinofficial/ztm.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zcoinofficial/ztm/context:csharp)
 
-This is a service for provide rich API for manage tokens on Zcoin Exodus Protocol.
+This is a service to provide rich API for manage tokens on Zcoin Exodus Protocol.
 
-## Requirements
+## Development
+
+### Requirements
 
 - .NET Core 2.2
 
-## Build
+### Build
 
 ```sh
 dotnet build src/Ztm.sln
 ```
 
-## Start Required Services
+### Start Required Services
 
 You need to install [Docker Compose](https://docs.docker.com/compose/) first then run:
 
@@ -21,35 +23,15 @@ You need to install [Docker Compose](https://docs.docker.com/compose/) first the
 docker-compose up -d
 ```
 
-## Create Database
-
-Enter database shell:
-
-```sh
-docker exec -it -u postgres ztm-db-main sh
-```
-
-Create a new role to be the owner of database:
-
-```sh
-createuser ztm
-```
-
-Then create a database:
-
-```sh
-createdb -O ztm ztm
-```
-
-## Migrate Database Schemas
+### Migrate Database Schemas
 
 Change directory to `src/Ztm.Data.Entity.Postgres` then run:
 
 ```sh
-ZTM_MAIN_DATABASE="Host=127.0.0.1;Database=ztm;Username=ztm" dotnet ef database update
+ZTM_MAIN_DATABASE="Host=127.0.0.1;Database=postgres;Username=postgres" dotnet ef database update
 ```
 
-## Start Zcoin Daemon
+### Start Zcoin Daemon
 
 Grab latest stable Zcoin binary from [here](https://github.com/zcoinofficial/zcoin/releases), extract or install it,
 then start Zcoin daemon:
@@ -58,7 +40,7 @@ then start Zcoin daemon:
 ./zcoind -testnet -printtoconsole -rpcuser=zcoin -rpcpassword=zcoin -zmqpubhashblock=tcp://127.0.0.1:28332
 ```
 
-## Start Web API
+### Start Web API
 
 ```sh
 dotnet run -p src/Ztm.WebApi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,7 @@
 version: '3.4'
 services:
   db-main:
-    image: postgres:11
+    image: postgres:10
     container_name: ztm-db-main
     ports:
       - 127.0.0.1:5432:5432
-    volumes:
-      - db-main:/var/lib/postgresql/data
-volumes:
-  db-main:
-    name: ztm-db-main


### PR DESCRIPTION
This will also change version from 11 to 10 too due to 11 is too new even Ubuntu 18.04 not supported.

Resolve #48.