### PR TITLE
Migrate transaction confirmation watcher

### DIFF
--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/ConfirmationWatcherTests.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/ConfirmationWatcherTests.cs
@@ -13,16 +13,16 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 {
     public sealed class ConfirmationWatcherTests
     {
-        readonly IConfirmationWatcherHandler<Watch> handler;
+        readonly IConfirmationWatcherHandler<Watch<object>, object> handler;
         readonly IBlocksStorage blocks;
         readonly TestConfirmationWatcher subject;
 
         public ConfirmationWatcherTests()
         {
-            this.handler = Substitute.For<IConfirmationWatcherHandler<Watch>>();
+            this.handler = Substitute.For<IConfirmationWatcherHandler<Watch<object>, object>>();
             this.blocks = Substitute.For<IBlocksStorage>();
             this.subject = new TestConfirmationWatcher(this.handler, this.blocks);
-            this.subject.CreateWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch>>>();
+            this.subject.CreateWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch<object>>>>();
         }
 
         [Fact]
@@ -39,12 +39,12 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
             this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(new[] { watch });
             this.blocks.GetAsync(block.GetHash(), Arg.Any<CancellationToken>()).Returns((block: block, height: 0));
-            this.handler.ConfirmationUpdateAsync(Arg.Any<Watch>(), Arg.Any<int>(), Arg.Any<ConfirmationType>(), Arg.Any<CancellationToken>()).Returns(false);
+            this.handler.ConfirmationUpdateAsync(Arg.Any<Watch<object>>(), Arg.Any<int>(), Arg.Any<ConfirmationType>(), Arg.Any<CancellationToken>()).Returns(false);
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -67,12 +67,12 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             // Arrange.
             var block0 = ZcoinNetworks.Instance.Regtest.GetGenesis();
             var block1 = Block.CreateBlock(ZcoinNetworks.Instance.Regtest);
-            var watch = new Watch(block0.GetHash());
+            var watch = new Watch<object>(null, block0.GetHash());
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
             this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(new[] { watch });
             this.blocks.GetAsync(block0.GetHash(), Arg.Any<CancellationToken>()).Returns((block: block0, height: 0));
-            this.handler.ConfirmationUpdateAsync(Arg.Any<Watch>(), Arg.Any<int>(), Arg.Any<ConfirmationType>(), Arg.Any<CancellationToken>()).Returns(false);
+            this.handler.ConfirmationUpdateAsync(Arg.Any<Watch<object>>(), Arg.Any<int>(), Arg.Any<ConfirmationType>(), Arg.Any<CancellationToken>()).Returns(false);
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -91,9 +91,9 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
             this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(new[] { watch });
             this.blocks.GetAsync(block.GetHash(), Arg.Any<CancellationToken>()).Returns((block: block, height: 0));
             this.handler.ConfirmationUpdateAsync(watch, 1, ConfirmationType.Confirmed, Arg.Any<CancellationToken>()).Returns(true);
@@ -113,7 +113,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
             this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
             this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(new[] { watch });
@@ -126,7 +126,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
                 await this.subject.ExecuteAsync(block, 0, BlockEventType.Added, cancellationSource.Token);
 
                 // Assert.
-                _ = this.handler.Received(0).RemoveWatchAsync(Arg.Any<Watch>(), Arg.Any<WatchRemoveReason>(), Arg.Any<CancellationToken>());
+                _ = this.handler.Received(0).RemoveWatchAsync(Arg.Any<Watch<object>>(), Arg.Any<WatchRemoveReason>(), Arg.Any<CancellationToken>());
             }
         }
     }

--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TestConfirmationWatcher.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TestConfirmationWatcher.cs
@@ -7,16 +7,16 @@ using Ztm.Zcoin.Synchronization.Watchers;
 
 namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 {
-    sealed class TestConfirmationWatcher : ConfirmationWatcher<Watch>
+    sealed class TestConfirmationWatcher : ConfirmationWatcher<Watch<object>, object>
     {
-        public TestConfirmationWatcher(IConfirmationWatcherHandler<Watch> handler, IBlocksStorage blocks)
+        public TestConfirmationWatcher(IConfirmationWatcherHandler<Watch<object>, object> handler, IBlocksStorage blocks)
             : base(handler, blocks)
         {
         }
 
-        public Func<Block, int, CancellationToken, IEnumerable<Watch>> CreateWatches { get; set; }
+        public Func<Block, int, CancellationToken, IEnumerable<Watch<object>>> CreateWatches { get; set; }
 
-        protected override Task<IEnumerable<Watch>> CreateWatchesAsync(
+        protected override Task<IEnumerable<Watch<object>>> CreateWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken)

--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TestWatcher.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TestWatcher.cs
@@ -7,19 +7,19 @@ using Ztm.Zcoin.Synchronization.Watchers;
 
 namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 {
-    sealed class TestWatcher : Watcher<Watch>
+    sealed class TestWatcher : Watcher<Watch<object>, object>
     {
-        public TestWatcher(IWatcherHandler<Watch> handler) : base(handler)
+        public TestWatcher(IWatcherHandler<Watch<object>, object> handler) : base(handler)
         {
         }
 
-        public Func<Block, int, CancellationToken, IEnumerable<Watch>> CreateWatches { get; set; }
+        public Func<Block, int, CancellationToken, IEnumerable<Watch<object>>> CreateWatches { get; set; }
 
-        public Func<Watch, Block, int, BlockEventType, CancellationToken, bool> ExecuteMatchedWatch { get; set; }
+        public Func<Watch<object>, Block, int, BlockEventType, CancellationToken, bool> ExecuteMatchedWatch { get; set; }
 
-        public Func<Block, int, CancellationToken, IEnumerable<Watch>> GetWatches { get; set; }
+        public Func<Block, int, CancellationToken, IEnumerable<Watch<object>>> GetWatches { get; set; }
 
-        protected override Task<IEnumerable<Watch>> CreateWatchesAsync(
+        protected override Task<IEnumerable<Watch<object>>> CreateWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken)
@@ -28,7 +28,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         }
 
         protected override Task<bool> ExecuteMatchedWatchAsync(
-            Watch watch,
+            Watch<object> watch,
             Block block,
             int height,
             BlockEventType blockEventType,
@@ -37,7 +37,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             return Task.FromResult(ExecuteMatchedWatch(watch, block, height, blockEventType, cancellationToken));
         }
 
-        protected override Task<IEnumerable<Watch>> GetWatchesAsync(
+        protected override Task<IEnumerable<Watch<object>>> GetWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken)

--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TransactionConfirmationWatcherTests.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TransactionConfirmationWatcherTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using NSubstitute;
+using Xunit;
+using Ztm.Zcoin.NBitcoin;
+using Ztm.Zcoin.Synchronization.Watchers;
+
+namespace Ztm.Zcoin.Synchronization.Tests.Watchers
+{
+    public sealed class TransactionConfirmationWatcherTests
+    {
+        readonly ITransactionConfirmationWatcherHandler<object> handler;
+        readonly IBlocksStorage blocks;
+        readonly TransactionConfirmationWatcher<object> subject;
+
+        public TransactionConfirmationWatcherTests()
+        {
+            this.handler = Substitute.For<ITransactionConfirmationWatcherHandler<object>>();
+            this.blocks = Substitute.For<IBlocksStorage>();
+            this.subject = new TransactionConfirmationWatcher<object>(this.handler, this.blocks);
+        }
+
+        [Fact]
+        public async Task CreateWatchesAsync_CreateContextsAsyncReturnEmptyList_ShouldNotCreateAnyWatches()
+        {
+            // Arrange.
+            var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
+
+            this.handler.CreateContextsAsync(Arg.Any<Transaction>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<object>());
+            this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<TransactionWatch<object>>());
+
+            using (var cancellationSource = new CancellationTokenSource())
+            {
+                // Act.
+                await this.subject.ExecuteAsync(block, 0, BlockEventType.Added, cancellationSource.Token);
+
+                // Assert.
+                _ = this.handler.Received(1).CreateContextsAsync(block.Transactions[0], cancellationSource.Token);
+                _ = this.handler.Received(0).AddWatchesAsync(Arg.Any<IEnumerable<TransactionWatch<object>>>(), Arg.Any<CancellationToken>());
+            }
+        }
+
+        [Fact]
+        public async Task CreateWatchesAsync_CreateContextsAsyncReturnNonEmptyList_ShouldCreateWatchesEqualToNumberOfContexts()
+        {
+            // Arrange.
+            var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
+            var ctx1 = new object();
+            var ctx2 = new object();
+
+            this.handler.CreateContextsAsync(Arg.Any<Transaction>(), Arg.Any<CancellationToken>()).Returns(new[] { ctx1, ctx2 });
+            this.handler.GetCurrentWatchesAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<TransactionWatch<object>>());
+
+            using (var cancellationSource = new CancellationTokenSource())
+            {
+                // Act.
+                await this.subject.ExecuteAsync(block, 0, BlockEventType.Added, cancellationSource.Token);
+
+                // Assert.
+                _ = this.handler.Received(1).CreateContextsAsync(block.Transactions[0], cancellationSource.Token);
+                _ = this.handler.Received(1).AddWatchesAsync(
+                    Arg.Is<IEnumerable<TransactionWatch<object>>>(l => l.Count() == 2 && l.First().Context == ctx1 && l.Last().Context == ctx2),
+                    cancellationSource.Token
+                );
+            }
+        }
+    }
+}

--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TransactionWatchTests.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/TransactionWatchTests.cs
@@ -1,0 +1,30 @@
+using System;
+using NBitcoin;
+using Xunit;
+using Ztm.Zcoin.Synchronization.Watchers;
+
+namespace Ztm.Zcoin.Synchronization.Tests.Watchers
+{
+    public sealed class TransactionWatchTests
+    {
+        [Fact]
+        public void Constructor_WithNullTxId_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>("txId", () => new TransactionWatch<object>(null, uint256.One, null));
+            Assert.Throws<ArgumentNullException>("txId", () => new TransactionWatch<object>(null, uint256.One, null, DateTime.Now));
+            Assert.Throws<ArgumentNullException>("txId", () => new TransactionWatch<object>(null, uint256.One, null, DateTime.Now, Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void TransactionId_WhenConstructed_ShouldSameAsConstructorArg()
+        {
+            var subject1 = new TransactionWatch<object>(null, uint256.One, uint256.One);
+            var subject2 = new TransactionWatch<object>(null, uint256.One, uint256.One, DateTime.Now);
+            var subject3 = new TransactionWatch<object>(null, uint256.One, uint256.One, DateTime.Now, Guid.NewGuid());
+
+            Assert.Equal(uint256.One, subject1.TransactionId);
+            Assert.Equal(uint256.One, subject2.TransactionId);
+            Assert.Equal(uint256.One, subject3.TransactionId);
+        }
+    }
+}

--- a/src/Ztm.Zcoin.Synchronization.Tests/Watchers/WatcherTests.cs
+++ b/src/Ztm.Zcoin.Synchronization.Tests/Watchers/WatcherTests.cs
@@ -13,16 +13,16 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 {
     public sealed class WatcherTests
     {
-        readonly IWatcherHandler<Watch> handler;
+        readonly IWatcherHandler<Watch<object>, object> handler;
         readonly TestWatcher subject;
 
         public WatcherTests()
         {
-            this.handler = Substitute.For<IWatcherHandler<Watch>>();
+            this.handler = Substitute.For<IWatcherHandler<Watch<object>, object>>();
             this.subject = new TestWatcher(this.handler);
-            this.subject.CreateWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch>>>();
-            this.subject.ExecuteMatchedWatch = Substitute.For<Func<Watch, Block, int, BlockEventType, CancellationToken, bool>>();
-            this.subject.GetWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch>>>();
+            this.subject.CreateWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch<object>>>>();
+            this.subject.ExecuteMatchedWatch = Substitute.For<Func<Watch<object>, Block, int, BlockEventType, CancellationToken, bool>>();
+            this.subject.GetWatches = Substitute.For<Func<Block, int, CancellationToken, IEnumerable<Watch<object>>>>();
         }
 
         [Fact]
@@ -45,8 +45,8 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
-            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
+            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -64,8 +64,8 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
-            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
+            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -84,14 +84,14 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
 
-            this.subject.CreateWatches(block, 0, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
-            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(block, 0, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
+            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
 
             // Act.
             await this.subject.ExecuteAsync(block, 0, BlockEventType.Added, CancellationToken.None);
 
             // Assert.
-            _ = this.handler.Received(0).AddWatchesAsync(Arg.Any<IEnumerable<Watch>>(), Arg.Any<CancellationToken>());
+            _ = this.handler.Received(0).AddWatchesAsync(Arg.Any<IEnumerable<Watch<object>>>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -99,10 +99,10 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
             this.subject.CreateWatches(block, 0, Arg.Any<CancellationToken>()).Returns(new[] { watch });
-            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -111,7 +111,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 
                 // Assert.
                 _ = this.handler.Received(1).AddWatchesAsync(
-                    Arg.Is<IEnumerable<Watch>>(l => l.SequenceEqual(new[] { watch })),
+                    Arg.Is<IEnumerable<Watch<object>>>(l => l.SequenceEqual(new[] { watch })),
                     cancellationSource.Token
                 );
             }
@@ -123,8 +123,8 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
-            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
+            this.subject.GetWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())
@@ -133,7 +133,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 
                 // Assert.
                 this.subject.ExecuteMatchedWatch.Received(0)(
-                    Arg.Any<Watch>(),
+                    Arg.Any<Watch<object>>(),
                     Arg.Any<Block>(),
                     Arg.Any<int>(),
                     Arg.Any<BlockEventType>(),
@@ -147,9 +147,9 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
             this.subject.GetWatches(block, 0, Arg.Any<CancellationToken>()).Returns(new[] { watch });
             this.subject.ExecuteMatchedWatch(watch, block, 0, BlockEventType.Added, Arg.Any<CancellationToken>()).Returns(true);
 
@@ -169,9 +169,9 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
-            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch>());
+            this.subject.CreateWatches(Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<Watch<object>>());
             this.subject.GetWatches(block, 0, Arg.Any<CancellationToken>()).Returns(new[] { watch });
             this.subject.ExecuteMatchedWatch(watch, block, 0, BlockEventType.Added, Arg.Any<CancellationToken>()).Returns(false);
 
@@ -182,7 +182,7 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
 
                 // Assert.
                 this.subject.ExecuteMatchedWatch.Received(1)(watch, block, 0, BlockEventType.Added, CancellationToken.None);
-                _ = this.handler.Received(0).RemoveWatchAsync(Arg.Any<Watch>(), Arg.Any<WatchRemoveReason>(), Arg.Any<CancellationToken>());
+                _ = this.handler.Received(0).RemoveWatchAsync(Arg.Any<Watch<object>>(), Arg.Any<WatchRemoveReason>(), Arg.Any<CancellationToken>());
             }
         }
 
@@ -191,10 +191,10 @@ namespace Ztm.Zcoin.Synchronization.Tests.Watchers
         {
             // Arrange.
             var block = ZcoinNetworks.Instance.Regtest.GetGenesis();
-            var watch = new Watch(block.GetHash());
+            var watch = new Watch<object>(null, block.GetHash());
 
             this.subject.GetWatches(block, 0, Arg.Any<CancellationToken>()).Returns(new[] { watch });
-            this.subject.ExecuteMatchedWatch(Arg.Any<Watch>(), Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<BlockEventType>(), Arg.Any<CancellationToken>()).Returns(false);
+            this.subject.ExecuteMatchedWatch(Arg.Any<Watch<object>>(), Arg.Any<Block>(), Arg.Any<int>(), Arg.Any<BlockEventType>(), Arg.Any<CancellationToken>()).Returns(false);
 
             // Act.
             using (var cancellationSource = new CancellationTokenSource())

--- a/src/Ztm.Zcoin.Synchronization/Watchers/ConfirmationWatcher.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/ConfirmationWatcher.cs
@@ -6,12 +6,14 @@ using NBitcoin;
 
 namespace Ztm.Zcoin.Synchronization.Watchers
 {
-    public abstract class ConfirmationWatcher<T> : Watcher<T> where T : Watch
+    public abstract class ConfirmationWatcher<TWatch, TContext> : Watcher<TWatch, TContext>
+        where TWatch : Watch<TContext>
     {
-        readonly IConfirmationWatcherHandler<T> handler;
+        readonly IConfirmationWatcherHandler<TWatch, TContext> handler;
         readonly IBlocksStorage blocks;
 
-        protected ConfirmationWatcher(IConfirmationWatcherHandler<T> handler, IBlocksStorage blocks) : base(handler)
+        protected ConfirmationWatcher(IConfirmationWatcherHandler<TWatch, TContext> handler, IBlocksStorage blocks)
+            : base(handler)
         {
             if (blocks == null)
             {
@@ -23,7 +25,7 @@ namespace Ztm.Zcoin.Synchronization.Watchers
         }
 
         protected override async Task<bool> ExecuteMatchedWatchAsync(
-            T watch,
+            TWatch watch,
             Block block,
             int height,
             BlockEventType blockEventType,
@@ -64,7 +66,7 @@ namespace Ztm.Zcoin.Synchronization.Watchers
             return await this.handler.ConfirmationUpdateAsync(watch, confirmation, confirmationType, cancellationToken);
         }
 
-        protected override Task<IEnumerable<T>> GetWatchesAsync(
+        protected override Task<IEnumerable<TWatch>> GetWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken)

--- a/src/Ztm.Zcoin.Synchronization/Watchers/IConfirmationWatcherHandler.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/IConfirmationWatcherHandler.cs
@@ -4,14 +4,14 @@ using System.Threading.Tasks;
 
 namespace Ztm.Zcoin.Synchronization.Watchers
 {
-    public interface IConfirmationWatcherHandler<T> : IWatcherHandler<T> where T : Watch
+    public interface IConfirmationWatcherHandler<TWatch, TContext> : IWatcherHandler<TWatch, TContext> where TWatch : Watch<TContext>
     {
         Task<bool> ConfirmationUpdateAsync(
-            T watch,
+            TWatch watch,
             int confirmation,
             ConfirmationType type,
             CancellationToken cancellationToken);
 
-        Task<IEnumerable<T>> GetCurrentWatchesAsync(CancellationToken cancellationToken);
+        Task<IEnumerable<TWatch>> GetCurrentWatchesAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Ztm.Zcoin.Synchronization/Watchers/ITransactionConfirmationWatcherHandler.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/ITransactionConfirmationWatcherHandler.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace Ztm.Zcoin.Synchronization.Watchers
+{
+    public interface ITransactionConfirmationWatcherHandler<TContext> : IConfirmationWatcherHandler<TransactionWatch<TContext>, TContext>
+    {
+        Task<IEnumerable<TContext>> CreateContextsAsync(Transaction tx, CancellationToken cancellationToken);
+    }
+}

--- a/src/Ztm.Zcoin.Synchronization/Watchers/IWatcherHandler.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/IWatcherHandler.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 
 namespace Ztm.Zcoin.Synchronization.Watchers
 {
-    public interface IWatcherHandler<T> where T : Watch
+    public interface IWatcherHandler<TWatch, TContext> where TWatch : Watch<TContext>
     {
-        Task AddWatchesAsync(IEnumerable<T> watches, CancellationToken cancellationToken);
+        Task AddWatchesAsync(IEnumerable<TWatch> watches, CancellationToken cancellationToken);
 
-        Task RemoveWatchAsync(T watch, WatchRemoveReason reason, CancellationToken cancellationToken);
+        Task RemoveWatchAsync(TWatch watch, WatchRemoveReason reason, CancellationToken cancellationToken);
     }
 }

--- a/src/Ztm.Zcoin.Synchronization/Watchers/TransactionConfirmationWatcher.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/TransactionConfirmationWatcher.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace Ztm.Zcoin.Synchronization.Watchers
+{
+    public sealed class TransactionConfirmationWatcher<TContext> : ConfirmationWatcher<TransactionWatch<TContext>, TContext>
+    {
+        readonly ITransactionConfirmationWatcherHandler<TContext> handler;
+
+        public TransactionConfirmationWatcher(ITransactionConfirmationWatcherHandler<TContext> handler, IBlocksStorage blocks)
+            : base(handler, blocks)
+        {
+            this.handler = handler;
+        }
+
+        protected override async Task<IEnumerable<TransactionWatch<TContext>>> CreateWatchesAsync(
+            Block block,
+            int height,
+            CancellationToken cancellationToken)
+        {
+            var watches = new Collection<TransactionWatch<TContext>>();
+
+            foreach (var tx in block.Transactions)
+            {
+                var contexts = await this.handler.CreateContextsAsync(tx, cancellationToken);
+
+                foreach (var context in contexts) {
+                    watches.Add(new TransactionWatch<TContext>(context, block.GetHash(), tx.GetHash()));
+                }
+            }
+
+            return watches;
+        }
+    }
+}

--- a/src/Ztm.Zcoin.Synchronization/Watchers/TransactionWatch.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/TransactionWatch.cs
@@ -1,0 +1,43 @@
+using System;
+using NBitcoin;
+
+namespace Ztm.Zcoin.Synchronization.Watchers
+{
+    public sealed class TransactionWatch<T> : Watch<T>
+    {
+        public TransactionWatch(T context, uint256 startBlock, uint256 txId)
+            : base(context, startBlock)
+        {
+            if (txId == null)
+            {
+                throw new ArgumentNullException(nameof(txId));
+            }
+
+            TransactionId = txId;
+        }
+
+        public TransactionWatch(T context, uint256 startBlock, uint256 txId, DateTime startTime)
+            : base(context, startBlock, startTime)
+        {
+            if (txId == null)
+            {
+                throw new ArgumentNullException(nameof(txId));
+            }
+
+            TransactionId = txId;
+        }
+
+        public TransactionWatch(T context, uint256 startBlock, uint256 txId, DateTime startTime, Guid id)
+            : base(context, startBlock, startTime, id)
+        {
+            if (txId == null)
+            {
+                throw new ArgumentNullException(nameof(txId));
+            }
+
+            TransactionId = txId;
+        }
+
+        public uint256 TransactionId { get; }
+    }
+}

--- a/src/Ztm.Zcoin.Synchronization/Watchers/Watch.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/Watch.cs
@@ -3,27 +3,32 @@ using NBitcoin;
 
 namespace Ztm.Zcoin.Synchronization.Watchers
 {
-    public class Watch
+    public class Watch<T>
     {
-        public Watch(uint256 startBlock) : this(startBlock, DateTime.Now)
+        public Watch(T context, uint256 startBlock)
+            : this(context, startBlock, DateTime.Now)
         {
         }
 
-        public Watch(uint256 startBlock, DateTime startTime) : this(startBlock, startTime, Guid.NewGuid())
+        public Watch(T context, uint256 startBlock, DateTime startTime)
+            : this(context, startBlock, startTime, Guid.NewGuid())
         {
         }
 
-        public Watch(uint256 startBlock, DateTime startTime, Guid id)
+        public Watch(T context, uint256 startBlock, DateTime startTime, Guid id)
         {
             if (startBlock == null)
             {
                 throw new ArgumentNullException(nameof(startBlock));
             }
 
+            Context = context;
             StartBlock = startBlock;
             StartTime = startTime;
             Id = id;
         }
+
+        public T Context { get; }
 
         public Guid Id { get; }
 
@@ -33,14 +38,14 @@ namespace Ztm.Zcoin.Synchronization.Watchers
 
         public override bool Equals(object obj)
         {
-            var other = obj as Watch;
+            var other = obj as Watch<T>;
 
             if (other == null || other.GetType() != GetType())
             {
                 return false;
             }
 
-            return other.Id == Id && other.StartBlock == StartBlock && other.StartTime == StartTime;
+            return other.Id == Id;
         }
 
         public override int GetHashCode()

--- a/src/Ztm.Zcoin.Synchronization/Watchers/Watcher.cs
+++ b/src/Ztm.Zcoin.Synchronization/Watchers/Watcher.cs
@@ -7,11 +7,11 @@ using NBitcoin;
 
 namespace Ztm.Zcoin.Synchronization.Watchers
 {
-    public abstract class Watcher<T> where T : Watch
+    public abstract class Watcher<TWatch, TContext> where TWatch : Watch<TContext>
     {
-        readonly IWatcherHandler<T> handler;
+        readonly IWatcherHandler<TWatch, TContext> handler;
 
-        protected Watcher(IWatcherHandler<T> handler)
+        protected Watcher(IWatcherHandler<TWatch, TContext> handler)
         {
             if (handler == null)
             {
@@ -27,7 +27,7 @@ namespace Ztm.Zcoin.Synchronization.Watchers
             BlockEventType eventType,
             CancellationToken cancellationToken)
         {
-            IEnumerable<T> watches;
+            IEnumerable<TWatch> watches;
 
             if (block == null)
             {
@@ -76,19 +76,19 @@ namespace Ztm.Zcoin.Synchronization.Watchers
             }
         }
 
-        protected abstract Task<IEnumerable<T>> CreateWatchesAsync(
+        protected abstract Task<IEnumerable<TWatch>> CreateWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken);
 
         protected abstract Task<bool> ExecuteMatchedWatchAsync(
-            T watch,
+            TWatch watch,
             Block block,
             int height,
             BlockEventType blockEventType,
             CancellationToken cancellationToken);
 
-        protected abstract Task<IEnumerable<T>> GetWatchesAsync(
+        protected abstract Task<IEnumerable<TWatch>> GetWatchesAsync(
             Block block,
             int height,
             CancellationToken cancellationToken);


### PR DESCRIPTION
We don't need address watcher anymore due to we don't need it. What we need is Exodus balance watcher, which need to implement from scratch (not included in this PR).

Resolve #76.